### PR TITLE
feat(eval-bridge): emit effective health, content quality and manifest signal

### DIFF
--- a/scripts/eval_bridge.py
+++ b/scripts/eval_bridge.py
@@ -602,6 +602,14 @@ def map_result_to_entry(entry: dict[str, Any], result: dict[str, Any] | None) ->
     evaluation["rubric_version"] = result.get("rubric_version")
     evaluation["evaluated_at"] = result.get("evaluated_at")
 
+    # content_quality: the LLM-only weighted subtotal (内容质量) — the α term of
+    # the blend `final = α·llm + (1-α)·health`. Persisted so consumers display it
+    # directly instead of re-deriving it from the metric dimensions with the
+    # wrong (per-task) weights.
+    llm_score = result.get("llm_score")
+    if llm_score is not None:
+        evaluation["content_quality"] = round(llm_score)
+
     entry["evaluation"] = evaluation
 
     # ── Map enrichment fields ──────────────────────────────────────────
@@ -665,16 +673,47 @@ def map_result_to_entry(entry: dict[str, Any], result: dict[str, Any] | None) ->
         else:
             freshness_label = "abandoned"
 
+        # effective_score: the (1-α) blend term — the weighted + star-routing
+        # redistributed health the final_score ACTUALLY uses, distinct from the
+        # simple-mean `score` above. Recovered exactly from the blend identity
+        # `final = α·llm + (1-α)·health` (α=0.85 across all task configs); the
+        # raw, un-rounded final_score and llm_score carry full precision here.
+        # Health-only entries (no llm_score) blend to `final = health`.
+        final_score_raw = result.get("final_score", 0.0) or 0.0
+        alpha = 0.85
+        if llm_score is not None:
+            effective_health = (final_score_raw - alpha * llm_score) / (1.0 - alpha)
+        else:
+            effective_health = final_score_raw
+
+        # excluded_signals: weighted health signals dropped from the blend, so the
+        # UI can explain why effective_score is below the simple-mean radar.
+        excluded_signals: list[str] = []
+        if result.get("star_weight", 1.0) == 0.0:
+            excluded_signals.append("popularity")
+        if entry.get("pushed_at") is None:
+            excluded_signals.append("freshness")
+
+        signals: dict[str, Any] = {
+            "freshness": round(freshness),
+            "popularity": round(popularity),
+            "source_trust": round(source_trust),
+            "install_popularity": round(install_popularity),
+        }
+        # manifest_completeness is a plugin-only signal (plugin.yaml weight 0.10);
+        # surface it (0-100) so the UI can render it, e.g. a 4th health-radar axis.
+        if entry.get("type") == "plugin":
+            signals["manifest_completeness"] = round(
+                raw_health.get("manifest_completeness", 0.0)
+            )
+
         entry["health"] = {
             "score": health_score,
+            "effective_score": round(effective_health),
+            "excluded_signals": excluded_signals,
             "freshness_label": freshness_label,
             "last_commit": entry.get("pushed_at"),
-            "signals": {
-                "freshness": round(freshness),
-                "popularity": round(popularity),
-                "source_trust": round(source_trust),
-                "install_popularity": round(install_popularity),
-            },
+            "signals": signals,
         }
 
     # Top-level promotion (consumed by sort + downstream scripts)

--- a/tests/test_eval_bridge.py
+++ b/tests/test_eval_bridge.py
@@ -402,3 +402,77 @@ class TestResolveTaskName:
         for t in ("mcp", "skill", "rule", "prompt"):
             config = load_task_config(resolve_task_name(t))
             assert config is not None
+
+
+class TestBlendDerivedHealth:
+    """effective_score / content_quality / excluded_signals / manifest axis are
+    derived in map_result_to_entry from the blend identity
+    ``final = α·llm + (1-α)·health`` (α=0.85), so downstream consumers display a
+    self-consistent breakdown instead of re-porting the scoring engine."""
+
+    @staticmethod
+    def _result(**over):
+        r = {
+            "metrics": {
+                "coding_relevance": {"score": 4}, "doc_completeness": {"score": 4},
+                "desc_accuracy": {"score": 5}, "writing_quality": {"score": 4},
+                "specificity": {"score": 4}, "install_clarity": {"score": 4},
+            },
+            "health": {"freshness": 100.0, "popularity": 100.0, "source_trust": 40.0},
+            "llm_score": 83.0,
+            "final_score": 80.407,  # 0.85*83 + 0.15*65.71
+            "decision": "accept", "star_weight": 0.0,
+            "model_id": "m", "rubric_version": "v", "evaluated_at": "t",
+        }
+        r.update(over)
+        return r
+
+    def test_skill_star_noise(self):
+        from eval_bridge import map_result_to_entry
+
+        entry = {"id": "azure", "type": "skill", "pushed_at": "2026-05-09T00:00:00Z"}
+        map_result_to_entry(entry, self._result())
+        assert entry["evaluation"]["content_quality"] == 83
+        assert entry["health"]["effective_score"] == 66  # round((80.407-70.55)/0.15)
+        assert entry["health"]["excluded_signals"] == ["popularity"]
+        assert entry["health"]["score"] == 80  # simple-mean radar unchanged
+        assert "manifest_completeness" not in entry["health"]["signals"]
+
+    def test_plugin_manifest_axis(self):
+        from eval_bridge import map_result_to_entry
+
+        entry = {"id": "sp", "type": "plugin", "pushed_at": "2026-06-09T00:00:00Z"}
+        result = self._result(
+            metrics={
+                "coding_relevance": {"score": 5}, "doc_completeness": {"score": 4},
+                "desc_accuracy": {"score": 5}, "writing_quality": {"score": 5},
+                "specificity": {"score": 5},
+            },
+            health={"freshness": 100.0, "popularity": 100.0, "source_trust": 100.0,
+                    "manifest_completeness": 70.0},
+            llm_score=94.0, final_score=94.45, star_weight=1.0,
+        )
+        map_result_to_entry(entry, result)
+        assert entry["evaluation"]["content_quality"] == 94
+        assert entry["health"]["effective_score"] == 97  # (94.45-79.9)/0.15
+        assert entry["health"]["excluded_signals"] == []
+        assert entry["health"]["signals"]["manifest_completeness"] == 70
+
+    def test_missing_pushed_at_excludes_freshness(self):
+        from eval_bridge import map_result_to_entry
+
+        entry = {"id": "x", "type": "skill", "pushed_at": None}
+        map_result_to_entry(entry, self._result(star_weight=1.0))
+        assert entry["health"]["excluded_signals"] == ["freshness"]
+
+    def test_health_only_has_no_content_quality(self):
+        from eval_bridge import map_result_to_entry
+
+        entry = {"id": "ho", "type": "plugin", "pushed_at": "2026-06-09T00:00:00Z"}
+        map_result_to_entry(entry, {
+            "metrics": {}, "llm_score": None, "final_score": 100.0,
+            "health": {"freshness": 100.0, "popularity": 100.0,
+                       "source_trust": 100.0, "manifest_completeness": 100.0},
+        })
+        assert "content_quality" not in entry["evaluation"]
+        assert entry["health"]["effective_score"] == 100  # final == health


### PR DESCRIPTION
## What

`map_result_to_entry` now serializes four scoring values that the blend already
computes but the catalog previously dropped, so downstream consumers (the catalog
detail page) can show a self-consistent "content_quality × 85% + health × 15%"
breakdown instead of re-implementing the scoring engine:

- `evaluation.content_quality` — the LLM-only weighted subtotal (the α term).
- `health.effective_score` — the (1-α) blend term: the weighted + star-routing
  redistributed health that `final_score` actually uses (distinct from the
  simple-mean `health.score`, which is unchanged). Recovered exactly from
  `final = α·llm + (1-α)·health` (α = 0.85).
- `health.excluded_signals` — which weighted signals were dropped from the blend
  (popularity on star-noise, freshness when `pushed_at` is missing).
- `health.signals.manifest_completeness` — surfaced for plugins so a UI can render
  it as a fourth health-radar axis.

## Why

Consumers were either showing the simple-mean `health.score` next to a formula
that uses a different (weighted, star-routed) health — so the numbers did not add
up — or re-porting the scoring weights client/server-side and drifting from this
repo. All four values are derived from fields already on the result dict
(`llm_score`, `final_score`, `star_weight`, `health`), so a catalog rebuild from
the eval cache picks them up with no re-evaluation.

## Tests

`tests/test_eval_bridge.py::TestBlendDerivedHealth` covers skill star-noise,
plugin manifest axis, missing-`pushed_at` freshness exclusion, and the
health-only (no `content_quality`) path.
