### PR TITLE
ci(cospower): mirror cospowers to self-hosted Gitea on sync

### DIFF
--- a/.github/workflows/sync-csc-plugins.yml
+++ b/.github/workflows/sync-csc-plugins.yml
@@ -135,6 +135,56 @@ jobs:
             --skip-marketplace \
             --yes
 
+      - name: Mirror cospowers to Gitea
+        # Only on main: Gitea is the production client-default marketplace source, so
+        # a preview run (csc_branch != main) must NOT force-mirror preview content to
+        # it — that would shift the default channel for ALL clients. Preview stays
+        # GitHub-side only; re-run with csc_branch=main to publish to Gitea.
+        if: ${{ (inputs.csc_branch || 'main') == 'main' }}
+        env:
+          GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          GITEA_USER: ${{ vars.GITEA_USER }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # Skip (not fail) when the Gitea secret is unconfigured. Gating inside the
+          # script (rather than a step-level `if: secrets.GITEA_TOKEN != ''`) emits an
+          # explicit skip line in the log and keeps the secret check next to its use.
+          # The GitHub-side publish above is never affected by this step.
+          if [ -z "${GITEA_TOKEN:-}" ]; then
+            echo ">> GITEA_TOKEN not set — skipping Gitea mirror"
+            exit 0
+          fi
+          if [ -z "${GITEA_USER:-}" ]; then
+            echo "::error title=cospower Gitea mirror::GITEA_TOKEN set but GITEA_USER (repo variable) missing" >&2
+            exit 1
+          fi
+          # Mirror the cospowers bare repos build.py just produced to the
+          # self-hosted Gitea (gitea.costrict.ai), so the device-side default
+          # marketplace source reflects this sync (clients default to Gitea).
+          # The mini csc build contains ONLY the 6 cospowers repos; they already
+          # exist on Gitea (no pre-create needed) and force-mirror is idempotent.
+          # Skipped entirely when GITEA_TOKEN is unset → GitHub flow unaffected.
+          BUNDLE="/tmp/csc-build/costrict-marketplace-bundle-vcsc-${{ github.run_number }}"
+          BASE="https://${GITEA_USER}:${GITEA_TOKEN}@gitea.costrict.ai/costrict-plugins-repo"
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 60
+          git config --global http.postBuffer 524288000
+          # Validate the repo set BEFORE pushing anything (nullglob → empty array if
+          # the bundle is missing), so a wrong count fails loud without partial writes.
+          bares=( "$BUNDLE"/repos/plugins/*.git )
+          if [ "${#bares[@]}" -ne 6 ]; then
+            echo "::error title=cospower Gitea mirror::expected 6 cospowers repos in bundle, found ${#bares[@]}" >&2
+            exit 1
+          fi
+          for bare in "${bares[@]}"; do
+            id="$(basename "$bare" .git)"
+            echo "::group::mirror $id -> Gitea"
+            git -C "$bare" push --force --mirror "$BASE/$id.git"
+            echo "::endgroup::"
+          done
+          echo ">> mirrored ${#bares[@]} cospowers repos to Gitea"
+
       # Only on main: a full release rebuilds the bundle + marketplace.json from
       # the COMMITTED catalog (main), which would re-publish main content over
       # the preview force-publish above and undo the preview. So it is force-


### PR DESCRIPTION
## 问题
plugin 分发链路终点 Gitea(`gitea.costrict.ai/costrict-plugins-repo`)是**设备端默认 marketplace 源**,但 GitHub→Gitea **没有任何自动同步**:`sync-csc-plugins.yml` 把 6 个 cospowers 仓 force-publish 到 GitHub 后就结束了,Gitea 永远拉不到更新。

**实测 drift**:`cospowers-requirements` GitHub HEAD=`55e2e6a` vs Gitea HEAD=`5a654ea`(6/25 的 cospower 更新没到 Gitea)。

## 改动(L1 — cospower 即时双写)
在 `sync-csc-plugins.yml` 现有 "Force-publish the cospowers plugin repos" 步骤后,新增一步 **"Mirror cospowers to Gitea"**:把 `build.py` 刚产出的 6 个 cospowers bare 仓 `git push --force --mirror` 到 Gitea。一次 dispatch = GitHub + Gitea 双写。

- **main-only**(`if: csc_branch == main`):Gitea 是客户端默认源,preview 运行不得 force-mirror 到它(否则瞬间切换所有客户端的默认内容)。
- **脚本内 token 守卫**:`GITEA_TOKEN` 未配 → skip(GitHub 侧流程完全不受影响)。
- **推前校验**:先确认正好 6 个仓再推(避免部分写入);6 仓已存在于 Gitea,force-mirror 幂等,无需预建。
- **凭证**:`GITEA_TOKEN`(secret)+ `GITEA_USER`(variable),URL 内嵌但不打日志;Actions 自动 mask;lowSpeed/postBuffer 守卫防僵死。

## 验证
- 两轮 cross-model dual review(trellis-check + Codex):Codex 抓的 P1(preview 污染生产 Gitea)+ P2(数量校验时机)已修;凭证零泄漏、守卫逻辑、路径对齐均核实通过。
- YAML lint + 提取脚本 `bash -n` 通过。
- **真机验证**(本 PR 合并/dispatch 后):比对 6 仓 GitHub vs Gitea HEAD 全等,drift 消除。

## 后续(L2,另开)
全量 bundle→Gitea:`release-bundle.yml` 发布 bundle 后自动推全量(含新增仓预建 + `import.sh` 大仓守卫)。

## 部署 / 配置
需在本仓配 `GITEA_TOKEN`(secret,Gitea write:repository PAT)+ `GITEA_USER`(variable=`costrict-plugins-repo`)。未配时该 step 自动跳过。
