### PR TITLE
feat(cosgraph): FULL-REPO mirror + hub listing for graphify

### DIFF
--- a/.github/workflows/sync-cosgraph-plugins.yml
+++ b/.github/workflows/sync-cosgraph-plugins.yml
@@ -134,24 +134,36 @@ jobs:
         # GITEA_TOKEN is unset (GitHub mirror above is unaffected).
         if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
         env:
+          # Same mechanism cospower uses (sync-csc-plugins.yml): the GITEA_TOKEN
+          # secret + GITEA_USER variable configured on this repo drive the Gitea push.
           GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          GITEA_USER: ${{ vars.GITEA_USER }}
         run: |
           set -euo pipefail
           if [ -z "${GITEA_TOKEN:-}" ]; then
             echo ">> GITEA_TOKEN not set — skipping Gitea mirror"
             exit 0
           fi
+          if [ -z "${GITEA_USER:-}" ]; then
+            echo "::error title=cos-graph Gitea mirror::GITEA_TOKEN set but GITEA_USER (repo variable) missing" >&2
+            exit 1
+          fi
+          # Large-push guards (same as cospower's Gitea step) — the full mirror is
+          # ~6MB with history, well within these.
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 60
+          git config --global http.postBuffer 524288000
           API=https://gitea.costrict.ai/api/v1
-          # Pre-create the Gitea repo if missing (Gitea disables push-to-create).
-          # costrict-plugins-repo is the Gitea account the token authenticates as,
-          # so create under /user/repos. 201=created, 409=already exists → both OK.
+          # Pre-create the Gitea repo if missing (Gitea disables push-to-create; unlike
+          # cospower's repos, graphify is new). costrict-plugins-repo is the Gitea account
+          # the token authenticates as → create under /user/repos. 201/409 both OK.
           code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API/user/repos" \
             -H "Authorization: token $GITEA_TOKEN" -H "Content-Type: application/json" \
             -d "{\"name\":\"${TARGET_REPO}\",\"private\":false,\"default_branch\":\"${CANONICAL_REF}\"}") || true
           echo ">> gitea create HTTP $code (201=created / 409=exists)"
-          # Push the full branch (token via header → stays out of argv/logs/URL).
-          git -C /tmp/cg-mirror -c http.extraHeader="Authorization: token ${GITEA_TOKEN}" \
-            push --force "https://gitea.costrict.ai/${TARGET_ORG}/${TARGET_REPO}.git" \
+          # Force-push the full branch (cospower-style URL creds: GITEA_USER:GITEA_TOKEN).
+          BASE="https://${GITEA_USER}:${GITEA_TOKEN}@gitea.costrict.ai/${TARGET_ORG}"
+          git -C /tmp/cg-mirror push --force "$BASE/${TARGET_REPO}.git" \
             "HEAD:refs/heads/${CANONICAL_REF}"
           # Ensure csc-plugin is the Gitea default branch too.
           curl -s -o /dev/null -w "gitea set-default HTTP %{http_code}\n" -X PATCH \

--- a/.github/workflows/sync-cosgraph-plugins.yml
+++ b/.github/workflows/sync-cosgraph-plugins.yml
@@ -1,0 +1,219 @@
+name: Sync cos-graph (graphify, first-party)
+
+# Manual re-sync of the first-party cos-graph plugin(s) from
+# https://github.com/xixingde/cos-graph (branch csc-plugin). Sibling of
+# sync-csc-plugins.yml (cospowers) — same first-party recipe, different source.
+# Unlike the bulk publish path (publish.sh --skip-existing, which SKIPS
+# already-published repos and so never updates their content), this workflow
+# **force-mirrors** the cos-graph plugin repo(s) so a re-run actually ships the
+# latest content.
+#
+# Steps:
+#   1. sync_plugins_cosgraph.py --overlay-catalog-index → upsert the entries into
+#      catalog/plugins/index.json (per-type) + catalog/index.json (top-level),
+#      preserving every other entry's enrichment. Commit + push.
+#   2. Targeted force-publish: check out the marketplace repo, build ONLY the
+#      cos-graph bare repos (full content — build.py honors prune_content=false),
+#      then publish.sh --skip-marketplace (force --mirror, NO --skip-existing) so
+#      costrict-plugins-repo/<id>.git always reflects the latest source.
+#   3. (optional) trigger the full release-catalog-bundle so the marketplace.json
+#      index + web catalog-bundle also refresh (needed when plugins are
+#      ADDED/REMOVED, or to refresh web hub visibility).
+#
+# Re-run anytime cos-graph updates: the script + build re-read the live tree.
+#
+# CANONICAL ref is `csc-plugin` (not `main`): cos-graph's default branch is
+# unrelated product code, so the plugin lives on `csc-plugin`. Every "commit the
+# canonical catalog / mirror to Gitea / full release" gate keys on
+# source_branch == 'csc-plugin'.
+#
+# PREVIEW MODE (source_branch != 'csc-plugin'): pull the plugin from a cos-graph
+# feature branch/tag to validate it BEFORE it merges to csc-plugin. In this mode
+# the workflow force-publishes the marketplace repos from that ref (so
+# `csc plugin install <name>@costrict-plugins` and the web hub's install both
+# fetch the branch content) but does NOT commit the canonical catalog index or
+# trigger a full release — so the reviewed catalog metadata stays clean.
+# Re-run with source_branch=csc-plugin to restore the marketplace repos.
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: "cos-graph ref (branch/tag) to sync from. Non-'csc-plugin' = PREVIEW: force-publish marketplace repos from that ref WITHOUT committing the canonical catalog or full release. Re-run with 'csc-plugin' to restore."
+        required: false
+        default: "csc-plugin"
+        type: string
+      trigger_full_release:
+        description: "Also trigger release-catalog-bundle (refresh marketplace.json index + web bundle). Needed when adding/removing a plugin. IGNORED unless source_branch is 'csc-plugin'."
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write   # commit + push the updated index files
+  actions: write    # dispatch release-catalog-bundle.yaml
+
+concurrency:
+  group: sync-cosgraph-plugins
+  cancel-in-progress: false
+
+jobs:
+  sync-and-publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      MARKETPLACE_REPO: costrict-plugins-repo/costrict-plugin-marketplace
+      ORG: costrict-plugins-repo
+    steps:
+      - name: Checkout catalog repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync cos-graph plugins (per-type + top-level overlay)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: "1"
+        run: python -u scripts/sync_plugins_cosgraph.py --overlay-catalog-index --branch "${{ inputs.source_branch || 'csc-plugin' }}"
+
+      # PREVIEW guard: only the canonical ref writes the canonical catalog. A
+      # feature-branch run keeps the dev source_url in the local checkout (so
+      # force-publish below clones the branch) but never commits it to the
+      # reviewed catalog.
+      - name: Commit & push index changes
+        if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
+        run: |
+          git config user.name  "costrict-build"
+          git config user.email "build@costrict.local"
+          git add catalog/plugins/index.json catalog/index.json
+          if git diff --cached --quiet; then
+            echo "No catalog changes — cos-graph already up to date."
+          else
+            git commit -m "chore(catalog): sync cos-graph plugins from xixingde/cos-graph"
+            git push
+          fi
+
+      - name: Preview-mode notice (catalog commit skipped)
+        if: ${{ (inputs.source_branch || 'csc-plugin') != 'csc-plugin' }}
+        run: |
+          echo "::notice title=Preview mode::source_branch='${{ inputs.source_branch }}' (not csc-plugin) —"
+          echo "skipping canonical catalog commit & full release; only force-publishing the"
+          echo "marketplace repos from this ref. Re-run with source_branch=csc-plugin to restore."
+
+      - name: Check out marketplace repo
+        uses: actions/checkout@v4
+        with:
+          repository: costrict-plugins-repo/costrict-plugin-marketplace
+          token: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
+          path: .marketplace
+          fetch-depth: 1
+
+      - name: Force-publish the cos-graph plugin repos (full content)
+        env:
+          GH_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The cos-graph entries → a mini catalog build.py can consume.
+          python3 - <<'PY'
+          import json
+          d = json.load(open("catalog/plugins/index.json"))
+          cg = [e for e in d if e.get("source") == "cos-graph"]
+          json.dump(cg, open("/tmp/cosgraph.json", "w"), ensure_ascii=False, indent=2)
+          print(f"cos-graph entries: {len(cg)} -> {[e['id'] for e in cg]}")
+          PY
+          VER="cosgraph-${{ github.run_number }}"
+          python3 .marketplace/scripts/build.py \
+            --version "$VER" \
+            --catalog /tmp/cosgraph.json \
+            --github-org "$ORG" \
+            --workers 4 \
+            --output /tmp/cosgraph-build
+          gh auth setup-git
+          # --skip-marketplace: do NOT touch marketplace.git (a mini build would
+          #   otherwise overwrite the full index with just these entries).
+          # NO --skip-existing: force --mirror so existing repos get the new content.
+          # publish.sh Phase 1 `gh repo create`s any missing GitHub repo, so a
+          # brand-new cos-graph plugin is auto-created on GitHub on first run.
+          .marketplace/scripts/publish.sh "/tmp/cosgraph-build/costrict-marketplace-bundle-v$VER" \
+            --org "$ORG" \
+            --skip-marketplace \
+            --yes
+
+      - name: Mirror cos-graph to Gitea
+        # Only on the canonical ref: Gitea is the production client-default
+        # marketplace source, so a preview run (source_branch != csc-plugin) must
+        # NOT force-mirror preview content to it — that would shift the default
+        # channel for ALL clients. Preview stays GitHub-side only; re-run with
+        # source_branch=csc-plugin to publish to Gitea.
+        if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
+        env:
+          GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
+          GITEA_USER: ${{ vars.GITEA_USER }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # Skip (not fail) when the Gitea secret is unconfigured. Gating inside the
+          # script (rather than a step-level `if: secrets.GITEA_TOKEN != ''`) emits an
+          # explicit skip line in the log and keeps the secret check next to its use.
+          # The GitHub-side publish above is never affected by this step.
+          if [ -z "${GITEA_TOKEN:-}" ]; then
+            echo ">> GITEA_TOKEN not set — skipping Gitea mirror"
+            exit 0
+          fi
+          if [ -z "${GITEA_USER:-}" ]; then
+            echo "::error title=cos-graph Gitea mirror::GITEA_TOKEN set but GITEA_USER (repo variable) missing" >&2
+            exit 1
+          fi
+          # Mirror the cos-graph bare repos build.py just produced to the
+          # self-hosted Gitea (gitea.costrict.ai), so the device-side default
+          # marketplace source reflects this sync (clients default to Gitea).
+          # NOTE: Gitea does NOT auto-create on push (unlike publish.sh's GitHub
+          # path). The target repo(s) must already exist on Gitea — pre-create
+          # costrict-plugins-repo/<id> on Gitea when onboarding a NEW plugin.
+          # force-mirror is idempotent once the repo exists.
+          # Skipped entirely when GITEA_TOKEN is unset → GitHub flow unaffected.
+          BUNDLE="/tmp/cosgraph-build/costrict-marketplace-bundle-vcosgraph-${{ github.run_number }}"
+          BASE="https://${GITEA_USER}:${GITEA_TOKEN}@gitea.costrict.ai/costrict-plugins-repo"
+          git config --global http.lowSpeedLimit 1000
+          git config --global http.lowSpeedTime 60
+          git config --global http.postBuffer 524288000
+          # Validate the repo set BEFORE pushing anything (nullglob → empty array if
+          # the bundle is missing), so an empty set fails loud without partial writes.
+          bares=( "$BUNDLE"/repos/plugins/*.git )
+          if [ "${#bares[@]}" -lt 1 ]; then
+            echo "::error title=cos-graph Gitea mirror::expected >=1 cos-graph repo in bundle, found ${#bares[@]}" >&2
+            exit 1
+          fi
+          for bare in "${bares[@]}"; do
+            id="$(basename "$bare" .git)"
+            echo "::group::mirror $id -> Gitea"
+            git -C "$bare" push --force --mirror "$BASE/$id.git"
+            echo "::endgroup::"
+          done
+          echo ">> mirrored ${#bares[@]} cos-graph repo(s) to Gitea"
+
+      # Only on the canonical ref: a full release rebuilds the bundle +
+      # marketplace.json from the COMMITTED catalog, which would re-publish
+      # canonical content over the preview force-publish above and undo the
+      # preview. So it is force-skipped for any non-canonical ref even if the box
+      # was ticked.
+      - name: (optional) Trigger Release Catalog Bundle
+        if: ${{ inputs.trigger_full_release && (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
+        env:
+          GH_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release-catalog-bundle.yaml --ref main -f publish_plugin_marketplace=true
+          echo "Dispatched release-catalog-bundle (index + web bundle refresh)."
+
+      - name: Full release skipped in preview mode
+        if: ${{ inputs.trigger_full_release && (inputs.source_branch || 'csc-plugin') != 'csc-plugin' }}
+        run: |
+          echo "::warning title=Full release skipped::trigger_full_release was requested but"
+          echo "source_branch='${{ inputs.source_branch }}' is not csc-plugin. A full release rebuilds"
+          echo "from the canonical catalog and would overwrite the preview content — skipped on purpose."

--- a/.github/workflows/sync-cosgraph-plugins.yml
+++ b/.github/workflows/sync-cosgraph-plugins.yml
@@ -1,69 +1,63 @@
-name: Sync cos-graph (graphify, first-party)
+name: Sync cos-graph (graphify FULL-REPO mirror, first-party)
 
-# Manual re-sync of the first-party cos-graph plugin(s) from
-# https://github.com/xixingde/cos-graph (branch csc-plugin). Sibling of
-# sync-csc-plugins.yml (cospowers) — same first-party recipe, different source.
-# Unlike the bulk publish path (publish.sh --skip-existing, which SKIPS
-# already-published repos and so never updates their content), this workflow
-# **force-mirrors** the cos-graph plugin repo(s) so a re-run actually ships the
-# latest content.
+# cos-graph is published as a FULL-REPO MIRROR — the ENTIRE xixingde/cos-graph
+# `csc-plugin` branch (the graphify/ Python package, docs, tests, tools, AND the
+# graphify-plugin/ plugin) — NOT a cospower-style extracted plugin subdir.
 #
-# Steps:
-#   1. sync_plugins_cosgraph.py --overlay-catalog-index → upsert the entries into
-#      catalog/plugins/index.json (per-type) + catalog/index.json (top-level),
-#      preserving every other entry's enrichment. Commit + push.
-#   2. Targeted force-publish: check out the marketplace repo, build ONLY the
-#      cos-graph bare repos (full content — build.py honors prune_content=false),
-#      then publish.sh --skip-marketplace (force --mirror, NO --skip-existing) so
-#      costrict-plugins-repo/<id>.git always reflects the latest source.
-#   3. (optional) trigger the full release-catalog-bundle so the marketplace.json
-#      index + web catalog-bundle also refresh (needed when plugins are
-#      ADDED/REMOVED, or to refresh web hub visibility).
+# Why not the cospower/build.py path: cos-graph's real substance lives OUTSIDE
+# the graphify-plugin/ subdir. build.py's find_plugin_root would rglob to
+# graphify-plugin/.claude-plugin/plugin.json and publish only that thin 11-file
+# wrapper, dropping graphify/, docs/, tests/. So we mirror the whole branch
+# verbatim with a dedicated git-mirror step instead.
 #
-# Re-run anytime cos-graph updates: the script + build re-read the live tree.
+# This workflow does three things:
+#   1. sync_plugins_cosgraph.py --overlay-catalog-index → catalog entry so
+#      graphify stays LISTED & SCORED in the web hub (first-party, verified).
+#      The entry carries external_mirror=true so costrict-plugin-marketplace's
+#      build.py SKIPS extracting/publishing its repo (which would clobber the
+#      full mirror). install.marketplace_repo points at the mirrored repo.
+#   2. FULL MIRROR: clone xixingde/cos-graph@<source_branch> and force-push the
+#      whole branch to costrict-plugins-repo/graphify on GitHub AND self-hosted
+#      Gitea (gitea.costrict.ai).
+#   3. (optional) trigger release-catalog-bundle to refresh the hub bundle.
 #
-# CANONICAL ref is `csc-plugin` (not `main`): cos-graph's default branch is
-# unrelated product code, so the plugin lives on `csc-plugin`. Every "commit the
-# canonical catalog / mirror to Gitea / full release" gate keys on
-# source_branch == 'csc-plugin'.
-#
-# PREVIEW MODE (source_branch != 'csc-plugin'): pull the plugin from a cos-graph
-# feature branch/tag to validate it BEFORE it merges to csc-plugin. In this mode
-# the workflow force-publishes the marketplace repos from that ref (so
-# `csc plugin install <name>@costrict-plugins` and the web hub's install both
-# fetch the branch content) but does NOT commit the canonical catalog index or
-# trigger a full release — so the reviewed catalog metadata stays clean.
-# Re-run with source_branch=csc-plugin to restore the marketplace repos.
+# CANONICAL ref is `csc-plugin`. A run with a different source_branch is PREVIEW:
+# it force-pushes that ref to GitHub under the SAME branch name (so you can eyeball
+# it) but does NOT commit the canonical catalog, does NOT mirror to Gitea, and does
+# NOT trigger a full release. Re-run with source_branch=csc-plugin to restore.
 
 on:
   workflow_dispatch:
     inputs:
       source_branch:
-        description: "cos-graph ref (branch/tag) to sync from. Non-'csc-plugin' = PREVIEW: force-publish marketplace repos from that ref WITHOUT committing the canonical catalog or full release. Re-run with 'csc-plugin' to restore."
+        description: "cos-graph ref (branch/tag) to FULL-mirror. Non-'csc-plugin' = PREVIEW: push that ref to GitHub only, no Gitea/canonical-catalog/full-release. Re-run with 'csc-plugin' to restore."
         required: false
         default: "csc-plugin"
         type: string
       trigger_full_release:
-        description: "Also trigger release-catalog-bundle (refresh marketplace.json index + web bundle). Needed when adding/removing a plugin. IGNORED unless source_branch is 'csc-plugin'."
+        description: "Also trigger release-catalog-bundle (refresh web hub bundle). IGNORED unless source_branch is 'csc-plugin'."
         required: false
         default: false
         type: boolean
 
 permissions:
-  contents: write   # commit + push the updated index files
+  contents: write   # commit + push the updated catalog index files
   actions: write    # dispatch release-catalog-bundle.yaml
 
 concurrency:
   group: sync-cosgraph-plugins
   cancel-in-progress: false
 
+env:
+  UPSTREAM_REPO: xixingde/cos-graph
+  TARGET_ORG: costrict-plugins-repo
+  TARGET_REPO: graphify
+  CANONICAL_REF: csc-plugin
+
 jobs:
-  sync-and-publish:
+  sync-and-mirror:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      MARKETPLACE_REPO: costrict-plugins-repo/costrict-plugin-marketplace
-      ORG: costrict-plugins-repo
     steps:
       - name: Checkout catalog repo
         uses: actions/checkout@v4
@@ -75,17 +69,14 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Sync cos-graph plugins (per-type + top-level overlay)
+      - name: Sync cos-graph catalog entry (per-type + top-level overlay)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONUNBUFFERED: "1"
         run: python -u scripts/sync_plugins_cosgraph.py --overlay-catalog-index --branch "${{ inputs.source_branch || 'csc-plugin' }}"
 
-      # PREVIEW guard: only the canonical ref writes the canonical catalog. A
-      # feature-branch run keeps the dev source_url in the local checkout (so
-      # force-publish below clones the branch) but never commits it to the
-      # reviewed catalog.
-      - name: Commit & push index changes
+      # PREVIEW guard: only the canonical ref writes the canonical catalog.
+      - name: Commit & push catalog changes
         if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
         run: |
           git config user.name  "costrict-build"
@@ -94,7 +85,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No catalog changes — cos-graph already up to date."
           else
-            git commit -m "chore(catalog): sync cos-graph plugins from xixingde/cos-graph"
+            git commit -m "chore(catalog): sync cos-graph (graphify) from xixingde/cos-graph"
             git push
           fi
 
@@ -102,118 +93,84 @@ jobs:
         if: ${{ (inputs.source_branch || 'csc-plugin') != 'csc-plugin' }}
         run: |
           echo "::notice title=Preview mode::source_branch='${{ inputs.source_branch }}' (not csc-plugin) —"
-          echo "skipping canonical catalog commit & full release; only force-publishing the"
-          echo "marketplace repos from this ref. Re-run with source_branch=csc-plugin to restore."
+          echo "mirroring that ref to GitHub only; skipping canonical catalog commit, Gitea mirror,"
+          echo "and full release. Re-run with source_branch=csc-plugin to restore."
 
-      - name: Check out marketplace repo
-        uses: actions/checkout@v4
-        with:
-          repository: costrict-plugins-repo/costrict-plugin-marketplace
-          token: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
-          path: .marketplace
-          fetch-depth: 1
-
-      - name: Force-publish the cos-graph plugin repos (full content)
+      - name: Full-mirror upstream branch → GitHub
         env:
+          MARKETPLACE_GITHUB_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
+          SOURCE_BRANCH: ${{ inputs.source_branch || 'csc-plugin' }}
         run: |
           set -euo pipefail
-          # The cos-graph entries → a mini catalog build.py can consume.
-          python3 - <<'PY'
-          import json
-          d = json.load(open("catalog/plugins/index.json"))
-          cg = [e for e in d if e.get("source") == "cos-graph"]
-          json.dump(cg, open("/tmp/cosgraph.json", "w"), ensure_ascii=False, indent=2)
-          print(f"cos-graph entries: {len(cg)} -> {[e['id'] for e in cg]}")
-          PY
-          VER="cosgraph-${{ github.run_number }}"
-          python3 .marketplace/scripts/build.py \
-            --version "$VER" \
-            --catalog /tmp/cosgraph.json \
-            --github-org "$ORG" \
-            --workers 4 \
-            --output /tmp/cosgraph-build
-          gh auth setup-git
-          # --skip-marketplace: do NOT touch marketplace.git (a mini build would
-          #   otherwise overwrite the full index with just these entries).
-          # NO --skip-existing: force --mirror so existing repos get the new content.
-          # publish.sh Phase 1 `gh repo create`s any missing GitHub repo, so a
-          # brand-new cos-graph plugin is auto-created on GitHub on first run.
-          .marketplace/scripts/publish.sh "/tmp/cosgraph-build/costrict-marketplace-bundle-v$VER" \
-            --org "$ORG" \
-            --skip-marketplace \
-            --yes
+          # Clone the WHOLE upstream branch (full history, verbatim). Single-branch
+          # keeps it to the ref we publish; the working tree is the full repo tree.
+          rm -rf /tmp/cg-mirror
+          git clone --single-branch --branch "$SOURCE_BRANCH" \
+            "https://github.com/${UPSTREAM_REPO}.git" /tmp/cg-mirror
+          echo ">> upstream ${UPSTREAM_REPO}@${SOURCE_BRANCH}: $(git -C /tmp/cg-mirror ls-files | wc -l) files, $(git -C /tmp/cg-mirror rev-list --count HEAD) commits"
+          # Force-push the full branch to our GitHub org repo under the SAME branch
+          # name (canonical csc-plugin, or the preview ref). publish.sh's gh-create
+          # is not used here — GitHub also won't push-to-create, so the target repo
+          # must already exist (created once during onboarding).
+          git -C /tmp/cg-mirror push --force \
+            "https://x-access-token:${MARKETPLACE_GITHUB_TOKEN}@github.com/${TARGET_ORG}/${TARGET_REPO}.git" \
+            "HEAD:refs/heads/${SOURCE_BRANCH}"
+          echo ">> pushed full mirror → github.com/${TARGET_ORG}/${TARGET_REPO}:${SOURCE_BRANCH}"
 
-      - name: Mirror cos-graph to Gitea
-        # Only on the canonical ref: Gitea is the production client-default
-        # marketplace source, so a preview run (source_branch != csc-plugin) must
-        # NOT force-mirror preview content to it — that would shift the default
-        # channel for ALL clients. Preview stays GitHub-side only; re-run with
-        # source_branch=csc-plugin to publish to Gitea.
+      - name: Make csc-plugin the default branch on GitHub
+        if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
+        env:
+          GH_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api -X PATCH "repos/${TARGET_ORG}/${TARGET_REPO}" -f default_branch="${CANONICAL_REF}" --jq '.default_branch'
+
+      - name: Full-mirror → Gitea
+        # Only on canonical: Gitea is the production client-default marketplace
+        # source, so a preview ref must NOT be mirrored there. Skipped when
+        # GITEA_TOKEN is unset (GitHub mirror above is unaffected).
         if: ${{ (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
         env:
           GITEA_TOKEN: ${{ secrets.GITEA_TOKEN }}
-          GITEA_USER: ${{ vars.GITEA_USER }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          # Skip (not fail) when the Gitea secret is unconfigured. Gating inside the
-          # script (rather than a step-level `if: secrets.GITEA_TOKEN != ''`) emits an
-          # explicit skip line in the log and keeps the secret check next to its use.
-          # The GitHub-side publish above is never affected by this step.
           if [ -z "${GITEA_TOKEN:-}" ]; then
             echo ">> GITEA_TOKEN not set — skipping Gitea mirror"
             exit 0
           fi
-          if [ -z "${GITEA_USER:-}" ]; then
-            echo "::error title=cos-graph Gitea mirror::GITEA_TOKEN set but GITEA_USER (repo variable) missing" >&2
-            exit 1
-          fi
-          # Mirror the cos-graph bare repos build.py just produced to the
-          # self-hosted Gitea (gitea.costrict.ai), so the device-side default
-          # marketplace source reflects this sync (clients default to Gitea).
-          # NOTE: Gitea does NOT auto-create on push (unlike publish.sh's GitHub
-          # path). The target repo(s) must already exist on Gitea — pre-create
-          # costrict-plugins-repo/<id> on Gitea when onboarding a NEW plugin.
-          # force-mirror is idempotent once the repo exists.
-          # Skipped entirely when GITEA_TOKEN is unset → GitHub flow unaffected.
-          BUNDLE="/tmp/cosgraph-build/costrict-marketplace-bundle-vcosgraph-${{ github.run_number }}"
-          BASE="https://${GITEA_USER}:${GITEA_TOKEN}@gitea.costrict.ai/costrict-plugins-repo"
-          git config --global http.lowSpeedLimit 1000
-          git config --global http.lowSpeedTime 60
-          git config --global http.postBuffer 524288000
-          # Validate the repo set BEFORE pushing anything (nullglob → empty array if
-          # the bundle is missing), so an empty set fails loud without partial writes.
-          bares=( "$BUNDLE"/repos/plugins/*.git )
-          if [ "${#bares[@]}" -lt 1 ]; then
-            echo "::error title=cos-graph Gitea mirror::expected >=1 cos-graph repo in bundle, found ${#bares[@]}" >&2
-            exit 1
-          fi
-          for bare in "${bares[@]}"; do
-            id="$(basename "$bare" .git)"
-            echo "::group::mirror $id -> Gitea"
-            git -C "$bare" push --force --mirror "$BASE/$id.git"
-            echo "::endgroup::"
-          done
-          echo ">> mirrored ${#bares[@]} cos-graph repo(s) to Gitea"
+          API=https://gitea.costrict.ai/api/v1
+          # Pre-create the Gitea repo if missing (Gitea disables push-to-create).
+          # costrict-plugins-repo is the Gitea account the token authenticates as,
+          # so create under /user/repos. 201=created, 409=already exists → both OK.
+          code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API/user/repos" \
+            -H "Authorization: token $GITEA_TOKEN" -H "Content-Type: application/json" \
+            -d "{\"name\":\"${TARGET_REPO}\",\"private\":false,\"default_branch\":\"${CANONICAL_REF}\"}") || true
+          echo ">> gitea create HTTP $code (201=created / 409=exists)"
+          # Push the full branch (token via header → stays out of argv/logs/URL).
+          git -C /tmp/cg-mirror -c http.extraHeader="Authorization: token ${GITEA_TOKEN}" \
+            push --force "https://gitea.costrict.ai/${TARGET_ORG}/${TARGET_REPO}.git" \
+            "HEAD:refs/heads/${CANONICAL_REF}"
+          # Ensure csc-plugin is the Gitea default branch too.
+          curl -s -o /dev/null -w "gitea set-default HTTP %{http_code}\n" -X PATCH \
+            "$API/repos/${TARGET_ORG}/${TARGET_REPO}" \
+            -H "Authorization: token $GITEA_TOKEN" -H "Content-Type: application/json" \
+            -d "{\"default_branch\":\"${CANONICAL_REF}\"}"
+          echo ">> pushed full mirror → gitea.costrict.ai/${TARGET_ORG}/${TARGET_REPO}:${CANONICAL_REF}"
 
-      # Only on the canonical ref: a full release rebuilds the bundle +
-      # marketplace.json from the COMMITTED catalog, which would re-publish
-      # canonical content over the preview force-publish above and undo the
-      # preview. So it is force-skipped for any non-canonical ref even if the box
-      # was ticked.
       - name: (optional) Trigger Release Catalog Bundle
+        # Refreshes the web hub bundle. publish_plugin_marketplace stays default
+        # (true) but graphify carries external_mirror=true so build.py skips its
+        # repo — the full mirror above is never clobbered.
         if: ${{ inputs.trigger_full_release && (inputs.source_branch || 'csc-plugin') == 'csc-plugin' }}
         env:
           GH_TOKEN: ${{ secrets.MARKETPLACE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run release-catalog-bundle.yaml --ref main -f publish_plugin_marketplace=true
-          echo "Dispatched release-catalog-bundle (index + web bundle refresh)."
+          echo "Dispatched release-catalog-bundle (web hub bundle refresh)."
 
       - name: Full release skipped in preview mode
         if: ${{ inputs.trigger_full_release && (inputs.source_branch || 'csc-plugin') != 'csc-plugin' }}
         run: |
-          echo "::warning title=Full release skipped::trigger_full_release was requested but"
-          echo "source_branch='${{ inputs.source_branch }}' is not csc-plugin. A full release rebuilds"
-          echo "from the canonical catalog and would overwrite the preview content — skipped on purpose."
+          echo "::warning title=Full release skipped::trigger_full_release requested but"
+          echo "source_branch='${{ inputs.source_branch }}' is not csc-plugin — skipped on purpose."

--- a/.github/workflows/sync-cosgraph-plugins.yml
+++ b/.github/workflows/sync-cosgraph-plugins.yml
@@ -109,10 +109,12 @@ jobs:
           git clone --single-branch --branch "$SOURCE_BRANCH" \
             "https://github.com/${UPSTREAM_REPO}.git" /tmp/cg-mirror
           echo ">> upstream ${UPSTREAM_REPO}@${SOURCE_BRANCH}: $(git -C /tmp/cg-mirror ls-files | wc -l) files, $(git -C /tmp/cg-mirror rev-list --count HEAD) commits"
+          # Create-if-missing (GitHub won't push-to-create). Idempotent — a no-op
+          # ("already exists") once the repo is onboarded; makes the first run
+          # self-sufficient without a manual pre-create.
+          gh repo create "${TARGET_ORG}/${TARGET_REPO}" --public --disable-issues --disable-wiki 2>&1 | tail -1 || echo "(repo already exists)"
           # Force-push the full branch to our GitHub org repo under the SAME branch
-          # name (canonical csc-plugin, or the preview ref). publish.sh's gh-create
-          # is not used here — GitHub also won't push-to-create, so the target repo
-          # must already exist (created once during onboarding).
+          # name (canonical csc-plugin, or the preview ref).
           git -C /tmp/cg-mirror push --force \
             "https://x-access-token:${MARKETPLACE_GITHUB_TOKEN}@github.com/${TARGET_ORG}/${TARGET_REPO}.git" \
             "HEAD:refs/heads/${SOURCE_BRANCH}"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -237,6 +237,18 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
 
+      # First-party cos-graph plugin(s) (xixingde/cos-graph @ csc-plugin). Same
+      # run-order rationale as the csc step above: runs AFTER official (full
+      # overwrite) + dev; this script merge-preserves too, so the cos-graph
+      # entries survive the weekly regen.
+      - name: Sync Plugins (cos-graph first-party)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYTHONUNBUFFERED: "1"
+        run: python -u scripts/sync_plugins_cosgraph.py
+        timeout-minutes: 5
+        continue-on-error: true
+
       # Stage A — active discovery (pure search, ZERO Tree API). GitHub Search
       # by stars → known_repos pre-filter → write candidate table
       # (.github_trending_cache/candidates.json). Runs after all curated/registry

--- a/scripts/sync_plugins_cosgraph.py
+++ b/scripts/sync_plugins_cosgraph.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""First-party cos-graph plugin sync (xixingde/cos-graph @ csc-plugin).
+
+Pulls the ``graphify`` plugin out of ``https://github.com/xixingde/cos-graph``
+(branch ``csc-plugin``) and merges it into ``catalog/plugins/index.json`` as a
+**first-party, marketplace-verified** plugin entry so it flows through the
+canonical pipeline:
+
+    catalog/plugins/index.json
+      → merge_index.py        → catalog/index.json
+      → download_catalog.py   → catalog-download/plugins/<id>/.plugin.json
+      → build_catalog_bundle  → catalog-bundle.tar.gz
+      → costrict-plugin-marketplace build.py --publish
+                              → costrict-plugins-repo/<id>.git + marketplace.git
+      → costrict-web migrate ingest-upstream
+                              → capability_items (web hub)
+
+This is the sibling of ``sync_plugins_csc.py`` (cospowers, yhangf/csc-plugins):
+same first-party recipe, different source repo/branch. A dedicated script per
+first-party source matches the existing per-source convention
+(``sync_plugins_official`` / ``sync_plugins_dev`` / ``sync_plugins_csc``) and
+keeps the proven cospowers path untouched.
+
+Why a dedicated first-party script instead of ``sync_plugins_official``:
+
+  - These are *first-party* (curated) plugins: they get a fixed
+    ``marketplace_verified=true`` and a fixed perfect ``final_score`` rather than
+    going through the upstream ai-resource-eval scoring pipeline.
+  - The plugin lives on a non-default branch (``csc-plugin``) of a repo whose
+    default branch is unrelated product code; the official sync would not target
+    it. cos-graph *does* carry a repo-root ``.claude-plugin/marketplace.json``,
+    but discovery here is subdir-driven (scan ``<subdir>/.claude-plugin/
+    plugin.json``), so the root marketplace.json is neither required nor read.
+
+Idempotency / "manual re-sync": this script **merge-preserves** —
+it loads the existing ``catalog/plugins/index.json``, drops any prior entries it
+owns (``source == "cos-graph"``), re-derives the entries from the *live*
+cos-graph tree (so version / description / bundle-count changes are picked up),
+and writes the union back. Re-running it == syncing the latest cos-graph.
+
+Run order: must run **after** ``sync_plugins_official.py`` (which overwrites the
+whole index) and may run before/after ``sync_plugins_dev.py`` /
+``sync_plugins_csc.py`` (all merge-preserve). See ``.github/workflows/sync.yml``
+/ ``sync-cosgraph-plugins.yml``.
+
+Implementation notes:
+  - Standard library only (urllib, json) — matches sync_plugins_official.py.
+  - Honors GITHUB_TOKEN for github.com / api.github.com / raw requests.
+  - Bundle counts (skills/commands/agents/hooks/mcp) are derived from a single
+    recursive Git Tree API call so they stay accurate across upstream changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import date
+from typing import Optional
+
+# Allow running both as `python scripts/sync_plugins_cosgraph.py` and as a module.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    from .utils import categorize, extract_tags, load_index, save_index  # type: ignore
+except ImportError:  # pragma: no cover - script-style invocation
+    from utils import categorize, extract_tags, load_index, save_index  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, ".."))
+OUTPUT_PATH = os.path.join(REPO_ROOT, "catalog", "plugins", "index.json")
+CATALOG_INDEX_PATH = os.path.join(REPO_ROOT, "catalog", "index.json")
+
+# The first-party source we own. Entries with this `source` are replaced
+# wholesale on every run (idempotent re-sync). `source_priority` sits at the
+# top so a (marketplace_repo, plugin_name) collision could never demote us.
+SOURCE_ID = "cos-graph"
+SOURCE_PRIORITY = 1000
+
+SOURCE_REPO = "xixingde/cos-graph"       # <owner>/<repo> — build/content source (not user-facing)
+SOURCE_BRANCH_DEFAULT = "csc-plugin"     # DEFAULT (canonical) ref; override per-run via --branch / $SOURCE_BRANCH
+
+# User-facing home: each cos-graph plugin is published as its own standard repo
+# under our org, which is what `csc plugin install <name>@costrict-plugins`
+# actually clones. install.marketplace_repo points here so the web hub's
+# "Upstream Source" link shows our repo, not the upstream product monorepo.
+# (source_url stays on SOURCE_REPO — it's the build clone source and is never
+# returned to the hub UI.)
+COSTRICT_ORG = "costrict-plugins-repo"
+
+# Self-own: first-party plugins get a fixed perfect score instead of the
+# upstream ai-resource-eval pipeline. 0-100 scale (web ingest maps
+# final_score -> capability_items.experience_score verbatim).
+FINAL_SCORE = 100
+
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "").strip()
+USER_AGENT = "everything-ai-coding-plugins-sync"
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger("sync_plugins_cosgraph")
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (stdlib only) — mirror sync_plugins_official.py
+# ---------------------------------------------------------------------------
+
+def _http_get(url: str, timeout: int = 30) -> Optional[bytes]:
+    headers = {"User-Agent": USER_AGENT}
+    is_github = (
+        "raw.githubusercontent.com" in url
+        or url.startswith("https://api.github.com/")
+        or "github.com" in url
+    )
+    if GITHUB_TOKEN and is_github:
+        headers["Authorization"] = f"token {GITHUB_TOKEN}"
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            logger.debug("404 Not Found: %s", url)
+        else:
+            logger.warning("HTTP %s for %s: %s", e.code, url, e.reason)
+        return None
+    except (urllib.error.URLError, TimeoutError) as e:
+        logger.warning("Network error for %s: %s", url, e)
+        return None
+    except Exception as e:  # noqa: BLE001 - keep the script robust
+        logger.warning("Unexpected error fetching %s: %s", url, e)
+        return None
+
+
+def _http_get_json(url: str, timeout: int = 30) -> Optional[dict | list]:
+    body = _http_get(url, timeout=timeout)
+    if body is None:
+        return None
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        logger.warning("JSON decode error for %s: %s", url, e)
+        return None
+
+
+def _raw_url(repo: str, branch: str, path: str) -> str:
+    return f"https://raw.githubusercontent.com/{repo}/{branch}/{path}"
+
+
+# ---------------------------------------------------------------------------
+# Discovery + bundle counting from the recursive Git Tree
+# ---------------------------------------------------------------------------
+
+def fetch_repo_meta(repo: str) -> dict:
+    """Fetch stars + pushed_at for the source repo (shared by all its plugins)."""
+    data = _http_get_json(f"https://api.github.com/repos/{repo}")
+    if not isinstance(data, dict):
+        return {"stars": 0, "pushed_at": None}
+    return {
+        "stars": data.get("stargazers_count") or 0,
+        "pushed_at": data.get("pushed_at"),
+    }
+
+
+def fetch_tree_paths(repo: str, branch: str) -> list[str]:
+    """Return every blob path in the repo via one recursive Git Tree API call."""
+    data = _http_get_json(
+        f"https://api.github.com/repos/{repo}/git/trees/{branch}?recursive=1"
+    )
+    if not isinstance(data, dict):
+        return []
+    if data.get("truncated"):
+        logger.warning("Git tree for %s@%s was truncated; counts may be partial", repo, branch)
+    return [
+        item["path"]
+        for item in data.get("tree", [])
+        if isinstance(item, dict) and item.get("type") == "blob" and item.get("path")
+    ]
+
+
+def resolve_branch_sha(repo: str, branch: str) -> Optional[str]:
+    """Resolve a branch name (which may contain ``/``) to its commit SHA.
+
+    ``git/trees`` and the ``raw.githubusercontent.com`` path both take the ref
+    as a single path segment, so a slash-containing branch like ``feat/x``
+    404s there. The ``git/ref/heads/<branch>`` endpoint captures the full ref
+    path, so resolve once and read content by the unambiguous SHA. Returns None
+    if the branch does not resolve to a single exact ref.
+    """
+    data = _http_get_json(f"https://api.github.com/repos/{repo}/git/ref/heads/{branch}")
+    # An exact match yields one ref object; a prefix match yields a list (reject).
+    if isinstance(data, dict):
+        sha = (data.get("object") or {}).get("sha")
+        if sha:
+            return sha
+    return None
+
+
+def discover_plugin_subdirs(tree_paths: list[str]) -> list[str]:
+    """Top-level subdirs that carry a `.claude-plugin/plugin.json` (sorted)."""
+    subdirs = set()
+    for path in tree_paths:
+        parts = path.split("/")
+        if len(parts) >= 3 and parts[1] == ".claude-plugin" and parts[2] == "plugin.json":
+            subdirs.add(parts[0])
+    return sorted(subdirs)
+
+
+def _empty_bundle() -> dict:
+    return {
+        "skills_count": 0,
+        "commands_count": 0,
+        "agents_count": 0,
+        "evaluators_count": 0,
+        "rules_count": 0,
+        "templates_count": 0,
+        "mcp_servers_count": 0,
+        "skills_namespaces": [],
+        "hooks_count": 0,
+        "hook_events": [],
+        "mcp_server_names": [],
+        "is_marketplace_repo": False,
+    }
+
+
+def _strip_md(rel: str) -> str:
+    """Drop a trailing ``.md`` from a repo-relative path used as a child name.
+
+    Single-file components (commands/agents/rules/templates) name themselves
+    after their repo-relative path; stripping the extension keeps the name
+    readable while preserving any nested group prefix (e.g. ``dfx/安全``).
+    """
+    return rel[:-3] if rel.endswith(".md") else rel
+
+
+def compute_bundle(tree_paths: list[str], subdir: str, plugin_name: str, branch: str = SOURCE_BRANCH_DEFAULT) -> dict:
+    """Derive bundle counts + child paths for one plugin subdir from the repo tree.
+
+    Every functional component directory is captured as a position-aligned
+    ``(<kind>_namespaces, <kind>_paths)`` pair so ``merge_index`` can synthesize
+    a standalone, path-faithful catalog entry per file/dir (``bundled_in`` →
+    this plugin):
+
+    - skills:     ``<subdir>/skills/<name>/SKILL.md``        DIRECTORY → type=skill
+    - evaluators: ``<subdir>/evaluators/<name>/SKILL.md``    DIRECTORY → type=skill
+    - commands:   ``<subdir>/commands/<file>``               FILE      → type=command
+    - agents:     ``<subdir>/agents/<file>.md``              FILE      → type=subagent
+    - rules:      ``<subdir>/rules/<group>/<file>.md`` (nested!) FILE  → type=rule
+    - templates:  ``<subdir>/templates/<file>.md``           FILE      → type=template
+
+    ``*_paths`` are repo-relative and verbatim (path-faithful — the web hub's
+    work tree mirrors the real on-disk layout). ``*_namespaces`` are
+    ``<plugin>:<name>`` where ``<name>`` is a stable per-component identifier
+    (directory name for dir-type, repo-relative-minus-extension for files;
+    rules keep their ``<group>/<file>`` shape so nested groups round-trip).
+    Both lists share the same sorted order so ``element[i]`` align.
+    """
+    bundle = _empty_bundle()
+    # name -> repo-relative SKILL.md path. merge_index orphan synthesis needs
+    # the path (position-aligned with skills_namespaces) plus source_repo/ref
+    # to materialize each bundled skill as a standalone catalog entry; without
+    # them the children silently stay un-synthesized (warn + None).
+    skill_paths_by_name: dict[str, str] = {}
+    evaluator_paths_by_name: dict[str, str] = {}
+    command_paths_by_name: dict[str, str] = {}
+    agent_paths_by_name: dict[str, str] = {}
+    rule_paths_by_name: dict[str, str] = {}
+    template_paths_by_name: dict[str, str] = {}
+    skills_prefix = f"{subdir}/skills/"
+    evaluators_prefix = f"{subdir}/evaluators/"
+    commands_prefix = f"{subdir}/commands/"
+    agents_prefix = f"{subdir}/agents/"
+    rules_prefix = f"{subdir}/rules/"
+    templates_prefix = f"{subdir}/templates/"
+
+    for path in tree_paths:
+        if path.startswith(skills_prefix) and path.endswith("/SKILL.md"):
+            # Directory-type child: name = first segment under skills/.
+            rel = path[len(skills_prefix):]
+            name = rel.split("/", 1)[0]
+            if name:
+                skill_paths_by_name.setdefault(name, path)
+        elif path.startswith(evaluators_prefix) and path.endswith("/SKILL.md"):
+            # Directory-type child (same shape as a skill, different dir).
+            rel = path[len(evaluators_prefix):]
+            name = rel.split("/", 1)[0]
+            if name:
+                evaluator_paths_by_name.setdefault(name, path)
+        elif path.startswith(commands_prefix):
+            # Single-file child: name = repo-relative path under commands/
+            # minus a trailing .md (keeps nested command groups distinct).
+            rel = path[len(commands_prefix):]
+            if rel and not rel.endswith("/"):
+                command_paths_by_name.setdefault(_strip_md(rel), path)
+        elif path.startswith(agents_prefix) and path.endswith(".md"):
+            rel = path[len(agents_prefix):]
+            if rel:
+                agent_paths_by_name.setdefault(_strip_md(rel), path)
+        elif path.startswith(rules_prefix) and path.endswith(".md"):
+            # Nested: rules/<group>/<file>.md — keep <group>/<file> so the id
+            # carries the group and stays collision-free across groups.
+            rel = path[len(rules_prefix):]
+            if rel:
+                rule_paths_by_name.setdefault(_strip_md(rel), path)
+        elif path.startswith(templates_prefix) and path.endswith(".md"):
+            rel = path[len(templates_prefix):]
+            if rel:
+                template_paths_by_name.setdefault(_strip_md(rel), path)
+
+    def _emit(kind_count: str, kind_ns: str, kind_paths: str, by_name: dict[str, str]) -> None:
+        names = sorted(by_name)
+        bundle[kind_count] = len(names)
+        bundle[kind_ns] = [f"{plugin_name}:{n}" for n in names]
+        bundle[kind_paths] = [by_name[n] for n in names]
+
+    _emit("skills_count", "skills_namespaces", "skill_paths", skill_paths_by_name)
+    _emit("evaluators_count", "evaluators_namespaces", "evaluator_paths", evaluator_paths_by_name)
+    _emit("commands_count", "commands_namespaces", "command_paths", command_paths_by_name)
+    _emit("agents_count", "agents_namespaces", "agent_paths", agent_paths_by_name)
+    _emit("rules_count", "rules_namespaces", "rule_paths", rule_paths_by_name)
+    _emit("templates_count", "templates_namespaces", "template_paths", template_paths_by_name)
+
+    bundle["source_repo"] = SOURCE_REPO
+    bundle["source_ref"] = branch
+    bundle["plugin_root"] = subdir
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# Per-plugin entry construction
+# ---------------------------------------------------------------------------
+
+def build_entry(
+    subdir: str,
+    tree_paths: list[str],
+    repo_meta: dict,
+    last_synced_iso: str,
+    branch: str = SOURCE_BRANCH_DEFAULT,
+    read_ref: Optional[str] = None,
+) -> Optional[dict]:
+    """Build a catalog entry for one cos-graph plugin subdir.
+
+    Reads the subdir's `plugin.json` (canonical name/description/version) and
+    `marketplace.json` (marketplace_name). Returns None if plugin.json is
+    unreadable or nameless.
+
+    `read_ref` is the ref used for the raw content reads (a commit SHA when the
+    branch contains a slash); `branch` stays the human-readable ref baked into
+    source_url / source_ref. They denote the same commit.
+    """
+    read_ref = read_ref or branch
+    plugin_json = _http_get_json(
+        _raw_url(SOURCE_REPO, read_ref, f"{subdir}/.claude-plugin/plugin.json")
+    )
+    if not isinstance(plugin_json, dict):
+        logger.warning("Skipping %s: cannot read .claude-plugin/plugin.json", subdir)
+        return None
+
+    name = (plugin_json.get("name") or "").strip()
+    if not name:
+        logger.warning("Skipping %s: plugin.json has no name", subdir)
+        return None
+
+    description = (plugin_json.get("description") or "").strip()
+    version = (plugin_json.get("version") or "").strip() or "0.0.0"
+
+    marketplace_json = _http_get_json(
+        _raw_url(SOURCE_REPO, read_ref, f"{subdir}/.claude-plugin/marketplace.json")
+    )
+    marketplace_name = None
+    if isinstance(marketplace_json, dict):
+        marketplace_name = (marketplace_json.get("name") or "").strip() or None
+    # download_catalog._download_plugin requires marketplace_name; fall back to
+    # the plugin name so the gate never trips for a first-party plugin. cos-graph
+    # keeps its marketplace.json at the repo root (not the subdir), so the subdir
+    # read above 404s and this fallback is the normal path here.
+    if not marketplace_name:
+        marketplace_name = name
+
+    # id == plugin name: clean first-party marketplace repo name
+    # (costrict-plugins-repo/graphify.git) and the same token the user types in
+    # `csc plugin install <name>@costrict-plugins`.
+    plugin_id = name
+
+    source_url = f"https://github.com/{SOURCE_REPO}/tree/{branch}/{subdir}"
+    tags = ["cos-graph", "knowledge-graph"] + extract_tags(name, description)
+    seen: set[str] = set()
+    tags = [t for t in tags if not (t in seen or seen.add(t))]
+    category = categorize(name=name, description=description, tags=tags)
+
+    bundle = compute_bundle(tree_paths, subdir, name, branch)
+
+    return {
+        "id": plugin_id,
+        "name": name,
+        "type": "plugin",
+        "description": description,
+        "source_url": source_url,
+        "category": category,
+        "tags": tags,
+        "tech_stack": [],
+        "source": SOURCE_ID,
+        "source_priority": SOURCE_PRIORITY,
+        "marketplace_url": f"https://github.com/{COSTRICT_ORG}/{plugin_id}",
+        "platforms": ["claude-code"],
+        "install": {
+            "method": "plugin_marketplace",
+            "plugin_name": name,
+            # Our own published repo (what csc actually installs from) — keeps the
+            # upstream product monorepo out of the hub's Upstream Source link.
+            "marketplace_repo": f"{COSTRICT_ORG}/{plugin_id}",
+            "marketplace_name": marketplace_name,
+            "marketplace_verified": True,
+            "marketplace": f"{COSTRICT_ORG}/{plugin_id}",
+        },
+        "bundle": bundle,
+        "manifest_completeness": 1.0,
+        "last_synced": last_synced_iso,
+        "stars": repo_meta.get("stars") or 0,
+        "pushed_at": repo_meta.get("pushed_at"),
+        "version": version,
+        # First-party: fixed perfect score + matching health, bypassing the
+        # ai-resource-eval pipeline (these never run through scoring).
+        "final_score": FINAL_SCORE,
+        "health": {
+            # freshness_label enum per catalog/schema.json: active|stale|abandoned
+            "score": FINAL_SCORE,
+            "freshness_label": "active",
+            "signals": {},
+        },
+        "verified": True,
+        # Mirror the source subdir verbatim in the marketplace (rules/, templates/,
+        # evaluators/, examples/, CLAUDE.md, …). costrict-plugin-marketplace/build.py
+        # reads this and skips its size-pruning for these entries.
+        "prune_content": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Merge-preserve into catalog/plugins/index.json
+# ---------------------------------------------------------------------------
+
+def merge_into_index(existing: list[dict], fresh: list[dict], sort: bool = True) -> list[dict]:
+    """Replace all prior `source == SOURCE_ID` entries with `fresh`, keep rest.
+
+    sort=True  → sort by id (readable diffs for the small per-type index).
+    sort=False → preserve the existing entries' order and append `fresh` at the
+                 end. Used for the 33MB top-level catalog/index.json so a re-sync
+                 produces a small diff instead of re-sorting the whole file.
+    """
+    kept = [e for e in existing if e.get("source") != SOURCE_ID]
+    merged = kept + fresh
+    if sort:
+        merged.sort(key=lambda e: e.get("id", ""))
+    return merged
+
+
+def collect_entries(branch: str = SOURCE_BRANCH_DEFAULT) -> list[dict]:
+    """Fetch the live cos-graph tree at `branch` and build all plugin entries."""
+    last_synced_iso = date.today().isoformat()
+    repo_meta = fetch_repo_meta(SOURCE_REPO)
+    # A slash-containing branch (feat/x) can't be read directly via git/trees or
+    # raw (single path segment), so resolve it to a commit SHA once and read all
+    # content by SHA, while keeping the human-readable `branch` for source_url /
+    # source_ref. Non-slash refs read directly (zero extra call, no regression).
+    read_ref = branch
+    if "/" in branch:
+        sha = resolve_branch_sha(SOURCE_REPO, branch)
+        if not sha:
+            logger.error("Cannot resolve branch %s@%s to a SHA — aborting", SOURCE_REPO, branch)
+            return []
+        logger.info("Resolved %s@%s → %s for content reads", SOURCE_REPO, branch, sha[:12])
+        read_ref = sha
+    tree_paths = fetch_tree_paths(SOURCE_REPO, read_ref)
+    if not tree_paths:
+        logger.error("Empty/failed git tree for %s@%s — aborting", SOURCE_REPO, branch)
+        return []
+    subdirs = discover_plugin_subdirs(tree_paths)
+    logger.info("Discovered %d plugin subdir(s): %s", len(subdirs), ", ".join(subdirs))
+
+    entries: list[dict] = []
+    for subdir in subdirs:
+        try:
+            entry = build_entry(subdir, tree_paths, repo_meta, last_synced_iso, branch, read_ref)
+        except Exception as e:  # noqa: BLE001 - never let one plugin kill the run
+            logger.warning("Failed to build entry for %s: %s", subdir, e)
+            continue
+        if entry is not None:
+            entries.append(entry)
+    return entries
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Sync xixingde/cos-graph (graphify) into catalog/plugins/index.json.",
+    )
+    parser.add_argument(
+        "--output",
+        default=OUTPUT_PATH,
+        help=f"Per-type plugins index.json path (default: {OUTPUT_PATH})",
+    )
+    parser.add_argument(
+        "--overlay-catalog-index",
+        action="store_true",
+        help=(
+            "Also surgically overlay the entries into the top-level "
+            "catalog/index.json (drop prior source=cos-graph, append fresh), "
+            "preserving every other entry's enrichment. Use this in the manual "
+            "sync workflow so the bundle picks them up WITHOUT a full "
+            "merge_index --skip-enrichment (which would wipe all scores). The "
+            "weekly sync omits this flag and lets merge_index rebuild instead."
+        ),
+    )
+    parser.add_argument(
+        "--catalog-index",
+        default=CATALOG_INDEX_PATH,
+        help=f"Top-level catalog index for --overlay-catalog-index (default: {CATALOG_INDEX_PATH})",
+    )
+    parser.add_argument(
+        "--branch",
+        default=os.environ.get("SOURCE_BRANCH", "").strip() or SOURCE_BRANCH_DEFAULT,
+        help=(
+            f"cos-graph ref (branch/tag) to sync from (default: ${{SOURCE_BRANCH}} or "
+            f"{SOURCE_BRANCH_DEFAULT!r}). A non-default ref pulls that branch's content into "
+            "every entry's source_url / source_ref so the marketplace build clones it; "
+            "use it to preview a branch before it merges to csc-plugin."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    # A present-but-blank --branch (e.g. an empty manual workflow input) must not
+    # become an empty ref — fall back to the default branch.
+    branch = (args.branch or "").strip() or SOURCE_BRANCH_DEFAULT
+    logger.info("Syncing cos-graph from %s@%s", SOURCE_REPO, branch)
+    fresh = collect_entries(branch)
+    if not fresh:
+        logger.error("Zero cos-graph plugins collected; exiting non-zero.")
+        return 1
+
+    existing = load_index(args.output)
+    merged = merge_into_index(existing, fresh)
+    save_index(merged, args.output)
+    logger.info(
+        "Synced %d cos-graph plugin(s) into %s (total entries now %d)",
+        len(fresh),
+        args.output,
+        len(merged),
+    )
+
+    if args.overlay_catalog_index:
+        top = load_index(args.catalog_index)
+        if not top:
+            logger.error(
+                "Top-level catalog index %s is empty/missing — cannot overlay.",
+                args.catalog_index,
+            )
+            return 1
+        # Preserve the huge top-level index's existing order; only the cos-graph
+        # entries move/append → small, reviewable diff per re-sync.
+        top_merged = merge_into_index(top, fresh, sort=False)
+        save_index(top_merged, args.catalog_index)
+        logger.info(
+            "Overlaid %d cos-graph plugin(s) into %s (total entries now %d, "
+            "other entries' enrichment preserved)",
+            len(fresh),
+            args.catalog_index,
+            len(top_merged),
+        )
+    for e in fresh:
+        logger.info(
+            "  %s  (skills=%d agents=%d, score=%d, source_url=%s)",
+            e["id"],
+            e["bundle"]["skills_count"],
+            e["bundle"]["agents_count"],
+            e["final_score"],
+            e["source_url"],
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_plugins_cosgraph.py
+++ b/scripts/sync_plugins_cosgraph.py
@@ -440,6 +440,16 @@ def build_entry(
         # evaluators/, examples/, CLAUDE.md, …). costrict-plugin-marketplace/build.py
         # reads this and skips its size-pruning for these entries.
         "prune_content": False,
+        # cos-graph is published as a FULL-REPO mirror (the entire csc-plugin branch,
+        # incl. the graphify/ package, docs, tests that live OUTSIDE graphify-plugin/),
+        # maintained by the dedicated mirror step in sync-cosgraph-plugins.yml — NOT by
+        # build.py's subdir extraction. This flag tells costrict-plugin-marketplace's
+        # build.py to SKIP building/publishing this plugin's bare repo (its find_plugin_root
+        # would otherwise rglob to graphify-plugin/ and clobber the full mirror with the
+        # 11-file thin wrapper). The entry still flows into the catalog-bundle so graphify
+        # stays listed & scored in the web hub; install.marketplace_repo points at the
+        # externally-mirrored repo.
+        "external_mirror": True,
     }
 
 

--- a/scripts/sync_plugins_cosgraph.py
+++ b/scripts/sync_plugins_cosgraph.py
@@ -1,36 +1,43 @@
 #!/usr/bin/env python3
-"""First-party cos-graph plugin sync (xixingde/cos-graph @ csc-plugin).
+"""First-party cos-graph catalog entry (xixingde/cos-graph @ csc-plugin).
 
-Pulls the ``graphify`` plugin out of ``https://github.com/xixingde/cos-graph``
-(branch ``csc-plugin``) and merges it into ``catalog/plugins/index.json`` as a
-**first-party, marketplace-verified** plugin entry so it flows through the
-canonical pipeline:
+Emits the web-hub CATALOG ENTRY for the ``graphify`` plugin. The repo CONTENT is
+published separately as a FULL-REPO MIRROR (see below) — this script only makes
+graphify listed & scored in the hub:
 
-    catalog/plugins/index.json
+    catalog/plugins/index.json  (this script; entry carries external_mirror=true)
       → merge_index.py        → catalog/index.json
-      → download_catalog.py   → catalog-download/plugins/<id>/.plugin.json
+      → download_catalog.py   → catalog-download/plugins/graphify/.plugin.json
       → build_catalog_bundle  → catalog-bundle.tar.gz
-      → costrict-plugin-marketplace build.py --publish
-                              → costrict-plugins-repo/<id>.git + marketplace.git
       → costrict-web migrate ingest-upstream
-                              → capability_items (web hub)
+                              → capability_items (web hub: graphify listed, scored)
 
-This is the sibling of ``sync_plugins_csc.py`` (cospowers, yhangf/csc-plugins):
-same first-party recipe, different source repo/branch. A dedicated script per
-first-party source matches the existing per-source convention
-(``sync_plugins_official`` / ``sync_plugins_dev`` / ``sync_plugins_csc``) and
-keeps the proven cospowers path untouched.
+The plugin's marketplace repo (``costrict-plugins-repo/graphify``) is NOT built
+by ``costrict-plugin-marketplace/build.py`` for this entry. cos-graph's substance
+(the ``graphify/`` Python package, docs, tests) lives OUTSIDE the
+``graphify-plugin/`` subdir, so it is published as a FULL mirror of the whole
+``csc-plugin`` branch by the dedicated git-mirror step in
+``.github/workflows/sync-cosgraph-plugins.yml``. The ``external_mirror=true`` flag
+(set on the entry below) makes build.py SKIP extracting/publishing this plugin's
+bare repo — otherwise ``find_plugin_root`` would rglob to ``graphify-plugin/`` and
+the pushed 11-file wrapper would clobber the full mirror.
+
+Sibling of ``sync_plugins_csc.py`` (cospowers, yhangf/csc-plugins): same
+first-party CATALOG recipe (fixed ``marketplace_verified=true`` + perfect
+``final_score``, bypassing ai-resource-eval), different source and publish model
+(cospowers = subdir extraction; cos-graph = full-repo mirror). A dedicated script
+per first-party source matches the existing per-source convention
+(``sync_plugins_official`` / ``sync_plugins_dev`` / ``sync_plugins_csc``).
 
 Why a dedicated first-party script instead of ``sync_plugins_official``:
 
-  - These are *first-party* (curated) plugins: they get a fixed
-    ``marketplace_verified=true`` and a fixed perfect ``final_score`` rather than
-    going through the upstream ai-resource-eval scoring pipeline.
+  - First-party (curated): fixed ``marketplace_verified=true`` + perfect
+    ``final_score`` instead of the upstream ai-resource-eval scoring pipeline.
   - The plugin lives on a non-default branch (``csc-plugin``) of a repo whose
     default branch is unrelated product code; the official sync would not target
-    it. cos-graph *does* carry a repo-root ``.claude-plugin/marketplace.json``,
-    but discovery here is subdir-driven (scan ``<subdir>/.claude-plugin/
-    plugin.json``), so the root marketplace.json is neither required nor read.
+    it. Discovery here is subdir-driven (scan ``<subdir>/.claude-plugin/
+    plugin.json`` → ``graphify-plugin``) purely to derive the hub METADATA
+    (name/version/bundle counts); the repo content comes from the full mirror.
 
 Idempotency / "manual re-sync": this script **merge-preserves** —
 it loads the existing ``catalog/plugins/index.json``, drops any prior entries it
@@ -85,15 +92,15 @@ CATALOG_INDEX_PATH = os.path.join(REPO_ROOT, "catalog", "index.json")
 SOURCE_ID = "cos-graph"
 SOURCE_PRIORITY = 1000
 
-SOURCE_REPO = "xixingde/cos-graph"       # <owner>/<repo> — build/content source (not user-facing)
+SOURCE_REPO = "xixingde/cos-graph"       # <owner>/<repo> — upstream mirror source (not user-facing)
 SOURCE_BRANCH_DEFAULT = "csc-plugin"     # DEFAULT (canonical) ref; override per-run via --branch / $SOURCE_BRANCH
 
-# User-facing home: each cos-graph plugin is published as its own standard repo
-# under our org, which is what `csc plugin install <name>@costrict-plugins`
-# actually clones. install.marketplace_repo points here so the web hub's
-# "Upstream Source" link shows our repo, not the upstream product monorepo.
-# (source_url stays on SOURCE_REPO — it's the build clone source and is never
-# returned to the hub UI.)
+# User-facing home: the full-repo mirror is published under our org as
+# costrict-plugins-repo/<name>, which is what `csc plugin install
+# <name>@costrict-plugins` clones. install.marketplace_repo points here so the web
+# hub's "Upstream Source" link shows our repo, not the upstream product repo.
+# (source_url below stays on SOURCE_REPO/<subdir> — used only to derive the hub
+# METADATA counts; the actual repo content is the full mirror, not this subdir.)
 COSTRICT_ORG = "costrict-plugins-repo"
 
 # Self-own: first-party plugins get a fixed perfect score instead of the


### PR DESCRIPTION
为 `xixingde/cos-graph@csc-plugin` 的 graphify 建第一方更新链路。**全量镜像模型**(非 cospower 抽子目录):`costrict-plugins-repo/graphify`(GitHub+Gitea)= 整个 csc-plugin 分支的逐字节镜像(含 graphify/ Python 包、docs、tests),因为插件真东西在 graphify-plugin/ 子目录**外面**。graphify 同时在 web 知识中心上架。

- `scripts/sync_plugins_cosgraph.py`:产出 hub catalog 条目(external_mirror=true,fixed 满分/verified)。
- `.github/workflows/sync-cosgraph-plugins.yml`:clone 上游 csc-plugin 全量 → force-push GitHub+Gitea(Gitea 用 GITEA_TOKEN secret,同 cospower)+ catalog overlay + 可选刷 hub bundle;分支预览模式。
- `.github/workflows/sync.yml`:周期性调 sync 脚本保 hub。

依赖 marketplace PR(build.py external_mirror 跳过)先合,否则全量 release 会抽取覆盖镜像。双评审 SHIP(全量镜像永不被覆盖 + graphify 仍在 hub 逐路径坐实)。